### PR TITLE
Return error when unable to resolve includes

### DIFF
--- a/cmd/sup/main.go
+++ b/cmd/sup/main.go
@@ -101,10 +101,14 @@ func runSupfile(errStream io.Writer, options options, args []string) error {
 	if err != nil {
 		return err
 	}
-	conf.ResolveIncludes(errStream, func(filename string) ([]byte, error) {
+	
+	if err := conf.ResolveIncludes(errStream, func(filename string) ([]byte, error) {
 		options.supfile = filename
 		return readSupfile(options)
-	})
+	}); err != nil {
+		return err
+	}
+	
 	// Parse network and commands to be run from flags.
 	network, commands, err := parseArgs(errStream, options, args, conf)
 	if err != nil {


### PR DESCRIPTION
If an included file had a syntax error, it wouldn't display any error.
This could lead a user to think the file is ok and that the problem is somewhere else.